### PR TITLE
Update class-admin-manager.php

### DIFF
--- a/admin/class-admin-manager.php
+++ b/admin/class-admin-manager.php
@@ -73,7 +73,7 @@ class Like_Button_For_Wordpress_Admin
               'administrator',
               'like-button-for-wordpress-admin-page',
               [$this, 'render_like_button_admin_page'],
-              '10'
+              10
           );
     }
 


### PR DESCRIPTION
Converted string to int in add_submenu_page() call. This is to fix an PHP error notice thrown by WP - called in the wrong way.